### PR TITLE
Fix memory issue detected by Guard Malloc

### DIFF
--- a/Source/CXMLNode_PrivateExtensions.m
+++ b/Source/CXMLNode_PrivateExtensions.m
@@ -110,9 +110,6 @@ return(_node);
     {
     if (_node)
         {
-        if (_node->_private == (__bridge void *)self)
-            _node->_private = NULL;
-
         if (_freeNodeOnRelease)
             {
             xmlUnlinkNode(_node);


### PR DESCRIPTION
This causes corruption of memory in apps. Bad bad bad. 
No need to clean this up anyway, as we are releasing this memory. 
Bridging self in dealloc, with ARC is not recommended.