### PR TITLE
Fix for include

### DIFF
--- a/Source/CXHTMLDocument.m
+++ b/Source/CXHTMLDocument.m
@@ -134,7 +134,7 @@
                 CFStringEncoding cfenc = CFStringConvertNSStringEncodingToEncoding(encoding);
                 CFStringRef cfencstr = CFStringConvertEncodingToIANACharSetName(cfenc);
                 const char *enc = CFStringGetCStringPtr(cfencstr, 0);
-                theDoc = htmlReadMemory([inData bytes], [inData length], NULL, enc, HTML_PARSE_NONET | HTML_PARSE_NOBLANKS | HTML_PARSE_NOWARNING);
+                theDoc = htmlReadMemory([inData bytes], (int)[inData length], NULL, enc, HTML_PARSE_NONET | HTML_PARSE_NOBLANKS | HTML_PARSE_NOWARNING);
                 }
 
             if (theDoc != NULL)

--- a/Source/CXMLDocument.h
+++ b/Source/CXMLDocument.h
@@ -31,7 +31,7 @@
 
 #import "CXMLNode.h"
 
-#include <tree.h>
+#include <libxml/tree.h>
 
 enum {
 	CXMLDocumentTidyHTML = 1 << 9, // Based on NSXMLDocumentTidyHTML

--- a/Source/CXMLDocument.m
+++ b/Source/CXMLDocument.m
@@ -127,7 +127,7 @@
                 CFStringEncoding cfenc = CFStringConvertNSStringEncodingToEncoding(encoding);
                 CFStringRef cfencstr = CFStringConvertEncodingToIANACharSetName(cfenc);
                 const char *enc = CFStringGetCStringPtr(cfencstr, 0);
-                theDoc = xmlCtxtReadMemory( self->xmlCtxt, [inData bytes], [inData length], NULL, enc, XML_PARSE_RECOVER | XML_PARSE_NOWARNING);
+                theDoc = xmlCtxtReadMemory( self->xmlCtxt, [inData bytes], (int)[inData length], NULL, enc, XML_PARSE_RECOVER | XML_PARSE_NOWARNING);
                 }
             
             if (theDoc != NULL && xmlDocGetRootElement(theDoc) != NULL)


### PR DESCRIPTION
CXMLDocument.h wouldn't compile on iOS due to <tree.h> include.

Also fixed some compiler warning about implicit casts.