### PR TITLE
Fix Implicit Conversion Warning in CXMLDocument

### DIFF
--- a/Source/CXMLDocument.h
+++ b/Source/CXMLDocument.h
@@ -51,6 +51,7 @@ enum {
 - (id)initWithXMLString:(NSString *)inString options:(NSUInteger)inOptions error:(NSError **)outError;
 - (id)initWithContentsOfURL:(NSURL *)inURL options:(NSUInteger)inOptions error:(NSError **)outError;
 - (id)initWithContentsOfURL:(NSURL *)inURL encoding:(NSStringEncoding)encoding options:(NSUInteger)inOptions error:(NSError **)outError;
+- (id)XMLStringWithOptions:(NSUInteger)options;
 
 //- (NSString *)characterEncoding;
 //- (NSString *)version;


### PR DESCRIPTION
Resolves warning 'Implicit conversion from enumeration type 'xmlElementType' to different enumeration type 'CXMLNodeKind'' in XCode 7