### PR TITLE
CXMLNode.m crash fix

### DIFF
--- a/Source/CXMLNode.m
+++ b/Source/CXMLNode.m
@@ -170,7 +170,9 @@ else
 		while (theCurrentNode != NULL)
 		{
 			CXMLNode *theNode = [CXMLNode nodeWithLibXMLNode:theCurrentNode freeOnDealloc:NO];
-			[theChildren addObject:theNode];
+			if (theNode) {
+				[theChildren addObject:theNode];
+			}
 			theCurrentNode = theCurrentNode->next;
 		}
 	}


### PR DESCRIPTION
Sometimes theNode can be nil, it causes crash of all application (adding nil to array).

Added check for nil.